### PR TITLE
feat: ファイルのアップロード失敗時にステータスコード500を返すようにプログラムを修正

### DIFF
--- a/src/server/server.go
+++ b/src/server/server.go
@@ -20,8 +20,12 @@ func UploadFileTest() func(c *gin.Context) {
 	return func(c *gin.Context) {
 		file, _ := c.FormFile("file")
 		log.Println(file.Filename)
-		c.SaveUploadedFile(file, fmt.Sprintf("./tmp/%s", file.Filename))
-		c.String(http.StatusOK, fmt.Sprintf("'%s' uploaded!", file.Filename))
+		err := c.SaveUploadedFile(file, fmt.Sprintf("./tmp/%s", file.Filename))
+		if err != nil {
+			c.String(http.StatusInternalServerError, fmt.Sprintf("Failed to upload '%s' !", file.Filename))
+		} else {
+			c.String(http.StatusOK, fmt.Sprintf("'%s' uploaded!", file.Filename))
+		}
 	}
 }
 


### PR DESCRIPTION
ファイルのアップロードが成功したらステータスコード200を、失敗したらステータスコード500を返すようにプログラムを修正しました。

ステータスコードについて詳しく理解したい場合は下のURLを見てみてください。
https://developer.mozilla.org/ja/docs/Web/HTTP/Status